### PR TITLE
Fix bug that ignores bypass and loop count functionality

### DIFF
--- a/force-app/main/default/classes/CustomMDTTriggerHandler.cls
+++ b/force-app/main/default/classes/CustomMDTTriggerHandler.cls
@@ -55,30 +55,9 @@ public with sharing class CustomMDTTriggerHandler extends TriggerHandler {
         continue;
       }
       
-      // dispatch to the correct handler method
-      switch on this.context {
-        when BEFORE_INSERT {
-          handler.beforeInsert();
-        }
-        when BEFORE_UPDATE {
-          handler.beforeUpdate();
-        }
-        when BEFORE_DELETE {
-          handler.beforeDelete();
-        }
-        when AFTER_INSERT {
-          handler.afterInsert();
-        }
-        when AFTER_UPDATE {
-          handler.afterUpdate();
-        }
-        when AFTER_DELETE {
-          handler.afterDelete();
-        }
-        when AFTER_UNDELETE {
-          handler.afterUndelete();
-        }
-      }
+      // Call default handler to provide bypass and MaxLoop functionality
+      handler.run();
+      
     }
   }
 


### PR DESCRIPTION
In the current version, the respective trigger context is called directly. This ensures that any bypass or loop counts are ignored.
The fix is relatively simple and only executes the original `run` method.